### PR TITLE
Fixed the install instructions and issue that caused the bookmarks icons container to lose color.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,14 +61,16 @@ To style the following widgets, please assign them the given id. For example, to
 
 #### Widget IDs for Dracula theme
 
+```
 | Widget   | ID                       | Example              |
 | -------- | ------------------------ | -------------------- |
 | Calendar | dracula-calendar         | id: dracula-calendar |
 | Glances  | glances-your_glance_name | id: glances-cpu      |
+```
 
 ### Icons
 
-All icons can be previewed [here](icons-preview.md).
+All icons can be previewed [here](https://github.com/dracula/homepage-app/blob/main/icons-preview.md).
 
 ```yaml
 - Portainer:

--- a/custom.css
+++ b/custom.css
@@ -145,7 +145,7 @@
   }
 
   .bookmark-icon {
-    background-color: var(--bookmark-icon-bg);
+    background-color: var(--bookmark-icon-bg) !important;
   }
 
   .bookmark-icon > div > div {


### PR DESCRIPTION
Installation instructions contain a table that cannot be displayed on the Dracula website. This was moved inside of a code block to maintain formatting.

Additionally, the icon link is invalid if clicked via the website therefor an absolute url was provided instead of a relative url.

With recent Homepage app updates, the css properties for bookmarks required an update to fix an issue where styling wasn't being applied to the icon container of the bookmark.